### PR TITLE
fix: Add check-fmt to python/lint in Makefile

### DIFF
--- a/modules/python/Makefile
+++ b/modules/python/Makefile
@@ -9,10 +9,9 @@ python/check: python/fmt python/lint python/test
 	@exit 0
 
 ## Lint Python code
-python/lint: python/typecheck
+python/lint: python/typecheck python/check-fmt
 	@echo "${GREEN}Running flake8 lint checks${RESET}"
 	@flake8 $(PY_FILES)
-	@isort --check-only --diff $(PACKAGE)
 
 ## Typecheck Python code
 python/typecheck:


### PR DESCRIPTION
Remove explicit `isort` check in Python lint target and add `check-fmt` as a dependency of lint instead.